### PR TITLE
Fix icon SVG props type

### DIFF
--- a/docs/src/app/layout-components/icon/page.tsx
+++ b/docs/src/app/layout-components/icon/page.tsx
@@ -63,7 +63,7 @@ const IconPage = () => {
         </tr>
         <tr>
           <Td>[SVG props]</Td>
-          <Td>{'SVGProps<SVGElement>'}</Td>
+          <Td>{'SVGProps<SVGSVGElement>'}</Td>
           <Td>You can pass all supported SVG props</Td>
         </tr>
         <UnderscoreClasses />

--- a/leda/components/Icon/types.ts
+++ b/leda/components/Icon/types.ts
@@ -9,7 +9,7 @@ export type IconProps = {
   strokeOpacity?: number | string | null;
   strokeWidth?: number | string | null;
   [x: string]: unknown;
-} & Omit<SVGProps<SVGElement>, 'fill' | 'stroke' | 'strokeOpacity' | 'strokeWidth'>;
+} & Omit<SVGProps<SVGSVGElement>, 'fill' | 'stroke' | 'strokeOpacity' | 'strokeWidth'>;
 
 export enum Icons {
   Calendar = 'calendar',


### PR DESCRIPTION
## Summary
- align Icon component types with correct React SVG element type
- fix documentation snippet about SVG props

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.*)*
- `npm run tsc` *(fails: Cannot find name 'expect' in tests)*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d16dfb3083269efef8b5e0af9fab