### PR TITLE
Add defaultValue for RadioGroup

### DIFF
--- a/chili/components/Radio/RadioGroup.tsx
+++ b/chili/components/Radio/RadioGroup.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { isFunction, isBoolean } from 'lodash';
 import { RadioButton } from './RadioButton';
 import {
-  getClassNames, useTheme, useElement, useProps,
+  getClassNames, useTheme, useElement, useProps, useValue,
 } from '../../utils';
 import { Div } from '../Div';
 import { COMPONENTS_NAMESPACES } from '../../constants';
@@ -16,6 +16,7 @@ export const RadioGroup = React.forwardRef((props: RadioGroupProps, ref?: React.
   const {
     children,
     className,
+    defaultValue,
     name,
     onChange,
     value: valueProp,
@@ -25,14 +26,15 @@ export const RadioGroup = React.forwardRef((props: RadioGroupProps, ref?: React.
 
   const theme = useTheme(props.theme, COMPONENTS_NAMESPACES.radio);
 
-  const [valueState, setValueState] = React.useState<string | number | undefined | null>();
-
-  const value = valueProp === undefined ? valueState : valueProp;
+  const [value, setValueState] = useValue<string | number | null | undefined>(
+    valueProp,
+    defaultValue ?? null,
+  );
 
   const { isValid, InvalidMessage } = useValidation(props, {
     value,
   }, {
-    reset: createResetHandler(props, setValueState),
+    reset: createResetHandler(props, setValueState, defaultValue),
   });
 
   const combinedClassNames = getClassNames(
@@ -51,7 +53,7 @@ export const RadioGroup = React.forwardRef((props: RadioGroupProps, ref?: React.
     Div,
     wrapperRender,
     props,
-    { value: valueState },
+    { value },
   );
 
   return (

--- a/chili/components/Radio/handlers.ts
+++ b/chili/components/Radio/handlers.ts
@@ -4,13 +4,15 @@ import type { RadioGroupProps } from './types';
 export const createResetHandler = (
   props: RadioGroupProps,
   setValue: SetState<string | number | null | undefined>,
+  defaultValue?: string | number | null,
 ) => () => {
-  setValue(null);
+  const newValue = defaultValue ?? null;
+  setValue(newValue);
 
   props.onChange?.({
     component: {
       name: props.name,
-      value: null,
+      value: newValue,
     },
   });
 };

--- a/chili/components/Radio/types.ts
+++ b/chili/components/Radio/types.ts
@@ -23,6 +23,8 @@ export interface RadioGroupProps extends ValidationProps {
   children: React.ReactNode,
   /** Whole component disabled state */
   isDisabled?: boolean,
+  /** Default value */
+  defaultValue?: string | number | null,
   /** Name */
   name?: string,
   /** Change handler */

--- a/docs/src/app/form-components/radio/_demo/Uncontrolled.tsx
+++ b/docs/src/app/form-components/radio/_demo/Uncontrolled.tsx
@@ -13,6 +13,7 @@ export const Uncontrolled = () => (
       onChange={({ component }) => {
         log(component.value)
       }}
+      defaultValue={2}
     >
       <L.RadioButton value={1}>One</L.RadioButton>
       <L.RadioButton value={2}>Two</L.RadioButton>

--- a/docs/src/app/form-components/radio/page.tsx
+++ b/docs/src/app/form-components/radio/page.tsx
@@ -39,6 +39,11 @@ const RadioPage = () => (
             <Td>...</Td>
           </tr>
           <tr>
+            <Td>defaultValue</Td>
+            <Td>number | string | null</Td>
+            <Td>Default value</Td>
+          </tr>
+          <tr>
             <Td>onChange</Td>
             <Td>(ev: ChangeEvent) ={'>'} void</Td>
             <Td>Change handler</Td>


### PR DESCRIPTION
## Summary
- add `defaultValue` to `RadioGroupProps`
- support uncontrolled initial value in `RadioGroup`
- update reset handler
- document the new prop and show an example

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687f5fb707008326b11d11ee9f792bcc