### PR TITLE
Update docs header with chili pepper logo

### DIFF
--- a/docs/src/components/header/MenuButton/index.tsx
+++ b/docs/src/components/header/MenuButton/index.tsx
@@ -12,16 +12,16 @@ export const MenuButton = ({
     className="
         mr-2
         border-0
-        bg-white
+        bg-[#09090b]
         py-2
-        text-stone-900
-        hover:bg-white
+        text-[#15803d]
+        hover:bg-[#09090b]
         md:hidden"
   >
     <L.Icon
       icon="menu"
       size={30}
-      className="text-black"
+      className="text-[#15803d]"
     />
   </L.Button>
 );

--- a/docs/src/components/header/index.tsx
+++ b/docs/src/components/header/index.tsx
@@ -29,15 +29,17 @@ export const MainHeader = ({
         <Image
           src="/chili_pepper.png"
           alt="Chili pepper"
-          width={24}
-          height={24}
+          width={50}
+          height={50}
           className="inline-block align-middle"
         />
-        <span className="ml-2 align-middle text-3xl font-sans text-[#dc2626]">
-          Chilii-UI
-        </span>
-        <span className="ml-2 align-middle text-xs text-[#15803d]">
-          {packageJson.version}
+        <span className="align-middle">
+          <span className="ml-1 font-sans text-xl text-[#dc2626]">
+            Chilii-UI
+          </span>
+          <span className="ml-2 text-base text-[#15803d]">
+            {packageJson.version}
+          </span>
         </span>
       </L.A>
       <div

--- a/docs/src/components/header/index.tsx
+++ b/docs/src/components/header/index.tsx
@@ -1,6 +1,7 @@
 import * as L from '@chili';
+import Image from 'next/image';
 import { MenuButton } from './MenuButton';
-import { greekFont } from '@/fonts';
+import packageJson from '../../../../package.json';
 
 export const MainHeader = ({
   isMenuOpen,
@@ -11,7 +12,8 @@ export const MainHeader = ({
 }) => (
   <div className="
       sticky top-0 z-20 border-b
-      border-slate-400 bg-white
+      border-slate-400 bg-[#09090b]
+      text-[#15803d]
     "
   >
     <div
@@ -22,23 +24,21 @@ export const MainHeader = ({
     >
       <L.A
         href="/"
-        className={`
-          inline-block
-          max-w-7xl
-          p-4 pt-5
-          ${greekFont.className}
-        `}
+        className="inline-block max-w-7xl p-4 pt-5"
       >
-        <span
-          className={`
-            text-3xl
-          `}
-        >
-          <span className="text-red-600">
-            Chili
-          </span>
+        <Image
+          src="/chili_pepper.png"
+          alt="Chili pepper"
+          width={24}
+          height={24}
+          className="inline-block align-middle"
+        />
+        <span className="ml-2 align-middle text-3xl font-sans text-[#dc2626]">
+          Chilii-UI
         </span>
-        <span className="ml-2 text-xs">0.1.1</span>
+        <span className="ml-2 align-middle text-xs text-[#15803d]">
+          {packageJson.version}
+        </span>
       </L.A>
       <div
         className="
@@ -50,13 +50,11 @@ export const MainHeader = ({
         <L.A
           href="https://github.com/chili-development/chili"
           target="_blank"
-          className="
-            p-3
-            md:mr-4
-          "
+          className="p-3 md:mr-4"
         >
           <L.Icon
             icon={L.IconTypes.Icons.Github}
+            className="text-[#15803d]"
           />
         </L.A>
         <MenuButton


### PR DESCRIPTION
## Summary
- use `chili_pepper.png` and add **Chilii-UI** text in docs header
- set docs version from `package.json`
- adjust header colors and font

## Testing
- `npm run tsc --prefix docs` *(fails: Cannot find module 'react')*
- `npm run check` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687f89c4c8848326868b9afebc9de8fa