### PR TITLE
Fix mobile menu button

### DIFF
--- a/chili/components/Icon/icons.tsx
+++ b/chili/components/Icon/icons.tsx
@@ -71,6 +71,11 @@ export const ICON_PATHS: Record<Icons, React.ReactNode[]> = {
   [Icons.Star]: [
     <polygon key="0" points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />,
   ],
+  [Icons.Menu]: [
+    <line key="0" x1="3" y1="12" x2="21" y2="12" />,
+    <line key="1" x1="3" y1="6" x2="21" y2="6" />,
+    <line key="2" x1="3" y1="18" x2="21" y2="18" />,
+  ],
   [Icons.X]: [
     <line key="0" x1="18" y1="6" x2="6" y2="18" />,
     <line key="1" x1="6" y1="6" x2="18" y2="18" />,

--- a/chili/components/Icon/types.ts
+++ b/chili/components/Icon/types.ts
@@ -31,5 +31,6 @@ export enum Icons {
   PlusSquare = 'plus-square',
   Square = 'square',
   Star = 'star',
+  Menu = 'menu',
   X = 'x',
 }

--- a/docs/src/components/header/MenuButton/index.tsx
+++ b/docs/src/components/header/MenuButton/index.tsx
@@ -19,7 +19,7 @@ export const MenuButton = ({
         md:hidden"
   >
     <L.Icon
-      icon="menu"
+      icon={L.IconTypes.Icons.Menu}
       size={30}
       className="text-[#15803d]"
     />


### PR DESCRIPTION
## Summary
- add new `Menu` icon in library
- update header menu button to use the new icon

## Testing
- `npm run check` *(fails: ESLint config not found)*
- `npm test` *(fails: jest not found)*
- `npm run tsc` *(fails: cannot find dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f8cd70090832699c730db6ade1419