### PR TITLE
Fix docs header width

### DIFF
--- a/docs/src/app/BaseLayout.tsx
+++ b/docs/src/app/BaseLayout.tsx
@@ -35,9 +35,10 @@ export const BaseLayout = ({
         isMenuOpen={isMenuOpen}
         setIsMenuOpen={setIsMenuOpen}
       />
-      <L.Div
-        className="overflow-hidden md:flex md:flex-row"
-      >
+      <div className="mx-auto max-w-7xl">
+        <L.Div
+          className="overflow-hidden md:flex md:flex-row"
+        >
         <L.Div
           shouldRender={!isMobile || isMenuOpen}
           onClick={(ev: React.MouseEvent<HTMLElement>) => {
@@ -57,7 +58,8 @@ export const BaseLayout = ({
         >
           { children }
         </L.Div>
-      </L.Div>
+        </L.Div>
+      </div>
     </div>
   );
 };

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -17,11 +17,9 @@ const RootLayout = ({
 }) => (
   <html lang="en">
     <body className={`${mainFont.className} bg-white`}>
-      <div className="mx-auto max-w-7xl">
-        <BaseLayout>
-          {children}
-        </BaseLayout>
-      </div>
+      <BaseLayout>
+        {children}
+      </BaseLayout>
       {process.env.MODE === 'prod' && (
         <>
           <Script src="/metrica.js" />

--- a/docs/src/components/header/index.tsx
+++ b/docs/src/components/header/index.tsx
@@ -18,13 +18,13 @@ export const MainHeader = ({
   >
     <div
       className="
-        flex
+        mx-auto flex max-w-7xl
         justify-between
       "
     >
       <L.A
         href="/"
-        className="inline-block max-w-7xl p-4 pt-5"
+        className="inline-block p-4 pt-5"
       >
         <Image
           src="/chili_pepper.png"


### PR DESCRIPTION
## Summary
- allow header background to span the entire viewport
- ensure main content remains centered

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8d8c008483269b0ddb92ffd740d1