### PR TITLE
Add autoComplete prop to MaskedInput

### DIFF
--- a/chili/components/MaskedInput/__snapshots__/MaskedInput.test.tsx.snap
+++ b/chili/components/MaskedInput/__snapshots__/MaskedInput.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`MaskedInput SNAPSHOTS should render different component states should r
           >
             <Input
               aria-invalid={false}
+              autoComplete="off"
               className="masked-input-element"
               disabled={true}
               mask="+# (###) ###-##-##"
@@ -45,6 +46,7 @@ exports[`MaskedInput SNAPSHOTS should render different component states should r
               >
                 <input
                   aria-invalid={false}
+                  autoComplete="off"
                   className="masked-input-element"
                   disabled={true}
                   maxLength={19}
@@ -99,6 +101,7 @@ exports[`MaskedInput SNAPSHOTS should render different component states should r
           >
             <Input
               aria-invalid={false}
+              autoComplete="off"
               className="masked-input-element"
               mask="+# (###) ###-##-##"
               onBlur={[Function]}
@@ -119,6 +122,7 @@ exports[`MaskedInput SNAPSHOTS should render different component states should r
               >
                 <input
                   aria-invalid={false}
+                  autoComplete="off"
                   className="masked-input-element"
                   disabled={false}
                   maxLength={19}

--- a/chili/components/MaskedInput/index.tsx
+++ b/chili/components/MaskedInput/index.tsx
@@ -14,6 +14,7 @@ import { getValue, getValueToValidate } from './helpers';
 
 export const MaskedInput = React.forwardRef((props: MaskedInputProps, ref: React.Ref<HTMLElement>) => {
   const {
+    autoComplete = 'off',
     className,
     defaultValue,
     inputRender,
@@ -138,6 +139,7 @@ export const MaskedInput = React.forwardRef((props: MaskedInputProps, ref: React
           {...restProps}
           aria-invalid={!isValid}
           aria-required={isRequired}
+          autoComplete={autoComplete}
           className={theme.input}
           isDisabled={isDisabled}
           mask={mask}

--- a/chili/components/MaskedInput/types.ts
+++ b/chili/components/MaskedInput/types.ts
@@ -23,6 +23,8 @@ export interface ResetEvent {
 export type ChangeEvent = BaseChangeEvent | ResetEvent;
 
 export interface MaskedInputProps extends ValidationProps {
+  /** Browser autofill, off is the default value. Works as HTML autoComplete attribute */
+  autoComplete?: string,
   /** Default value */
   defaultValue?: string,
   /** Input customizator. It replaces MaskedInputBase! */

--- a/chili/src/MaskedInputBase/index.tsx
+++ b/chili/src/MaskedInputBase/index.tsx
@@ -19,6 +19,7 @@ export const MaskedInputBase = React.forwardRef((props: MaskedInputBaseProps, re
     className,
     mask,
     value,
+    autoComplete,
     placeholderChar = DEFAULT_PLACEHOLDER_CHAR,
     placeholder,
     isDisabled = false,
@@ -90,6 +91,7 @@ export const MaskedInputBase = React.forwardRef((props: MaskedInputBaseProps, re
     <input
       disabled={isDisabled}
       className={className}
+      autoComplete={autoComplete}
       maxLength={mask.length + 1}
       onBlur={handleBlur}
       onFocus={handleFocus}

--- a/chili/src/MaskedInputBase/types.ts
+++ b/chili/src/MaskedInputBase/types.ts
@@ -68,6 +68,7 @@ export interface MaskedInputBaseProps {
   isDisabled?: boolean,
   mask: string,
   maxLength?: number,
+  autoComplete?: string,
   name?: string,
   onBlur?: (event: BlurEvent) => void,
   onChange: (event: ChangeEvent) => void,

--- a/docs/src/app/form-components/masked-input/page.tsx
+++ b/docs/src/app/form-components/masked-input/page.tsx
@@ -4,7 +4,7 @@
 
 import * as L from '@chili';
 import { ShouldRender, UnderscoreClasses } from '@/components/commonProps';
-import { CodeBlock, H1, Td } from '@/components/typography';
+import { A, P, CodeBlock, H1, Td } from '@/components/typography';
 import { Live } from '@/components/live';
 import { CustomizationPropsTableSection, PropsTableSection, ValidationSection } from '@/sections';
 import { Demos } from './Demos';
@@ -13,6 +13,23 @@ const MaskedInputPage = () => (
   <article>
     <H1>MaskedInput</H1>
     <PropsTableSection>
+      <tr>
+        <Td>autoComplete</Td>
+        <Td>string</Td>
+        <Td>
+          <P>Browser autofill, off is the default value.</P>
+          <P>Works as&nbsp;
+            <A
+              href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete"
+              target="_blank"
+              className="text-cyan-700 underline"
+              rel="noreferrer"
+            >
+              HTML autoComplete attribute
+            </A>
+          </P>
+        </Td>
+      </tr>
       <tr>
         <Td>defaultValue</Td>
         <Td>string | null</Td>


### PR DESCRIPTION
## Summary
- support `autoComplete` prop in `MaskedInput` and `MaskedInputBase`
- document new `autoComplete` option
- update snapshots

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: jest not found)*
- `npm run tsc` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68863b0872cc8326bc7ab8324ebec177