### PR TITLE
Update docs link color

### DIFF
--- a/docs/src/components/nav/NavLi.tsx
+++ b/docs/src/components/nav/NavLi.tsx
@@ -15,7 +15,7 @@ export const NavLi = ({ to, children }: { to: string, children: ReactNode }) => 
         href={to}
         className={isActive
           ? 'inline-block border-l border-slate-800 py-1 pl-2'
-          : 'inline-block border-l py-1 pl-2 text-sky-600 hover:border-sky-200 hover:text-sky-800'}
+          : 'inline-block border-l py-1 pl-2 text-green-700 hover:border-green-200 hover:text-green-800'}
       >
         {children}
       </Link>

--- a/docs/src/components/typography/A.tsx
+++ b/docs/src/components/typography/A.tsx
@@ -8,7 +8,7 @@ export const A = ({
   ...rest
 }: AProps) => {
   const classNames = classnames(
-    'text-sky-600',
+    'text-green-700',
     'underline',
     className,
   );


### PR DESCRIPTION
## Summary
- use `text-green-700` for docs links in `A` component and navigation items
- remove global anchor styling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68863b6b8bc4832684e294a811d0d966