### PR TITLE
Document autocomplete prop

### DIFF
--- a/chili/components/DropDownSelect/types.ts
+++ b/chili/components/DropDownSelect/types.ts
@@ -57,6 +57,7 @@ export interface FocusEvent<T extends Value = Value> extends React.FocusEvent<HT
 }
 
 export interface DropDownSelectProps<T extends Value = Value> extends ValidationProps {
+  /** Browser autofill, off is the default value. Works as HTML autoComplete attribute */
   autoComplete?: string,
   boundingContainerRef?: React.RefObject<HTMLElement>,
   compareObjectsBy?: T extends object ? ((suggestionListItem: T) => unknown) | string : never,

--- a/docs/src/app/form-components/dropdown-select/page.tsx
+++ b/docs/src/app/form-components/dropdown-select/page.tsx
@@ -18,8 +18,8 @@ const DropDownSelectPage = () => (
 
     <PropsTableSection>
       <tr>
-        <Td>autoComplete</Td>
-        <Td>string</Td>
+        <TdCode>autoComplete</TdCode>
+        <TdCode>string</TdCode>
         <Td>
           <P>Browser autofill, off is the default value.</P>
           <P>Works as&nbsp;


### PR DESCRIPTION
## Summary
- document DropDownSelect `autoComplete` prop in TS types
- use `TdCode` for `autoComplete` in DropDownSelect docs

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run test` *(fails: jest not found)*
- `npm run tsc` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68863b9b8f248326b3f67756bc2fc9c5