### PR TITLE
Add placeholder styling for NumericTextBox

### DIFF
--- a/chili/components/NumericTextBox/types.ts
+++ b/chili/components/NumericTextBox/types.ts
@@ -115,6 +115,8 @@ export interface NumericTextBoxProps extends ValidationProps {
   onEnterPress?: (event: EnterPressEvent) => void,
   /** Focus handler */
   onFocus?: (event: FocusEvent) => void,
+  /** Placeholder */
+  placeholder?: string,
   /** Ref */
   ref?: React.Ref<HTMLElement>,
   /** To trim or not to trim */

--- a/docs/src/app/form-components/numeric-text-box/page.tsx
+++ b/docs/src/app/form-components/numeric-text-box/page.tsx
@@ -75,6 +75,11 @@ const NumericTextBoxPage = () => (
         <Td>Focus handler</Td>
       </tr>
       <tr>
+        <Td>placeholder</Td>
+        <Td>string</Td>
+        <Td>Placeholder</Td>
+      </tr>
+      <tr>
         <Td>shouldTrimTrailingZeros</Td>
         <Td>boolean</Td>
         <Td>To trim or not to trim</Td>

--- a/styles/themes/base/base.variables.css
+++ b/styles/themes/base/base.variables.css
@@ -147,6 +147,7 @@
   --ld-input-bg-color: var(--ld-bg-color);
   --ld-input-element-bg-color: transparent;
   --ld-input-bg-color-disabled: var(--ld-bg-color-disabled);
+  --ld-input-placeholder-color: var(--ld-base-color);
 
   --ld-invalid-message-color: var(--ld-color-danger);
 

--- a/styles/themes/base/common/input.css
+++ b/styles/themes/base/common/input.css
@@ -12,6 +12,10 @@
   background-color: var(--ld-input-element-bg-color);
 }
 
+.ld-input-element::placeholder {
+  color: var(--ld-input-placeholder-color);
+}
+
 .ld-input-element-wrapper {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- style placeholder color for input elements
- export placeholder prop in NumericTextBox types
- document placeholder prop for NumericTextBox

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test` *(fails: jest not found)*
- `npm run tsc` *(fails: could not run without deps)*

------
https://chatgpt.com/codex/tasks/task_e_68863c7b63108326a33b7f96aa18a56a