### PR TITLE
Add defaultValue to DatePicker

### DIFF
--- a/chili/components/DatePicker/handlers.ts
+++ b/chili/components/DatePicker/handlers.ts
@@ -1,0 +1,16 @@
+import { isFunction } from 'lodash';
+import type { SetState } from '../../commonTypes';
+import type { DatePickerProps, ChangeEvent } from './types';
+
+export const createChangeHandler = (
+  props: DatePickerProps,
+  setUncontrolledValue: SetState<string | Date | null>,
+) => (ev: ChangeEvent): void => {
+  const { onChange, value } = props;
+
+  if (value === undefined) {
+    setUncontrolledValue(ev.component.date ?? ev.component.value);
+  }
+
+  if (isFunction(onChange)) onChange(ev);
+};

--- a/chili/components/DatePicker/index.tsx
+++ b/chili/components/DatePicker/index.tsx
@@ -4,14 +4,32 @@ import * as React from 'react';
 import { DateTimeInput } from '../../src/DateTimeInput';
 import { COMPONENT_TYPES } from '../../src/DateTimeInput/constants';
 import type { DatePickerProps } from './types';
+import { useValue, useProps } from '../../utils';
+import { createChangeHandler } from './handlers';
 
-export const DatePicker = React.forwardRef((props: DatePickerProps, ref: React.Ref<HTMLElement>) => (
-  <DateTimeInput
-    {...props}
-    format={props.format || 'dd.MM.yyyy'}
-    type={COMPONENT_TYPES.DATE_ONLY}
-    ref={ref}
-  />
-)) as React.FC<DatePickerProps>;
+export const DatePicker = React.forwardRef((rawProps: DatePickerProps, ref: React.Ref<HTMLElement>) => {
+  const props = useProps(rawProps);
+
+  const {
+    defaultValue = null,
+    value: valueProp,
+    ...restProps
+  } = props;
+
+  const [value, setUncontrolledValue] = useValue<string | Date | null>(valueProp, defaultValue);
+
+  const handleChange = createChangeHandler(props, setUncontrolledValue);
+
+  return (
+    <DateTimeInput
+      {...restProps}
+      value={value}
+      onChange={handleChange}
+      format={props.format || 'dd.MM.yyyy'}
+      type={COMPONENT_TYPES.DATE_ONLY}
+      ref={ref}
+    />
+  );
+}) as React.FC<DatePickerProps>;
 
 DatePicker.displayName = 'DatePicker';

--- a/chili/components/DatePicker/types.ts
+++ b/chili/components/DatePicker/types.ts
@@ -9,6 +9,8 @@ import type {
 import type { PartialGlobalDefaultTheme } from '../../utils/useTheme';
 
 export interface DatePickerProps extends DateTimeInputProps {
+  /** Default value */
+  defaultValue?: string | Date | null,
   /** Date format, dd.MM.yyyy by default */
   format?: string,
   /** Control opened state */

--- a/chili/src/DateTimeInput/handlers/handleReset.ts
+++ b/chili/src/DateTimeInput/handlers/handleReset.ts
@@ -1,7 +1,8 @@
 import type * as React from 'react';
-import { isFunction } from 'lodash';
+import { isFunction, isDate } from 'lodash';
 import type { DateTimeInputProps, AllActions } from '../types';
 import { setDate, setValue } from '../actions';
+import { stringToDate, formatDateTime } from '../helpers';
 
 export const createResetHandler = ({
   props,
@@ -10,14 +11,25 @@ export const createResetHandler = ({
   props: DateTimeInputProps,
   dispatch: React.Dispatch<AllActions>,
 }) => () => {
-  const date = null;
-  const value = '';
+  const { defaultValue, format = 'dd.MM.yyyy', name, onChange } = props;
+
+  const date = (() => {
+    if (isDate(defaultValue)) return defaultValue;
+    if (typeof defaultValue === 'string') return stringToDate(defaultValue, format);
+    return null;
+  })();
+
+  const value = (() => {
+    if (isDate(defaultValue)) return formatDateTime(defaultValue, format);
+    if (typeof defaultValue === 'string') return defaultValue;
+    return '';
+  })();
   dispatch(setValue(value));
   dispatch(setDate(date));
-  if (isFunction(props.onChange)) {
-    props.onChange({
+  if (isFunction(onChange)) {
+    onChange({
       component: {
-        name: props.name,
+        name,
         date,
         value,
       },

--- a/chili/src/DateTimeInput/hooks.ts
+++ b/chili/src/DateTimeInput/hooks.ts
@@ -7,7 +7,7 @@ import { VIEW_TYPES } from '../CalendarBase/constants';
 import { MaskedInputBase } from '../MaskedInputBase';
 import { setDate, setViewDate } from './actions';
 import {
-  stringToDate,
+  stringToDate, formatDateTime,
 } from './helpers';
 import { stateReducer } from './reducer';
 import type {
@@ -59,7 +59,7 @@ export const useDateTimeInputEffects = ({
 
 export const useDateTimeInputState = (props: DateTimeInputProps): [DateTimeInputState, React.Dispatch<AllActions>] => {
   const {
-    value: valueProp, format, min, max,
+    value: valueProp, defaultValue, format = 'dd.MM.yyyy', min, max,
   } = props;
 
   // if today's date is out of min/max range - open the calendar with the min/max date instead
@@ -69,11 +69,25 @@ export const useDateTimeInputState = (props: DateTimeInputProps): [DateTimeInput
   // today's date, the time is 00:00
   const today = new Date();
 
-  const stringValue = isDate(valueProp) || valueProp === null ? '' : valueProp;
+  const initialPropValue = valueProp === undefined ? defaultValue : valueProp;
+
+  const initialDate = (() => {
+    if (isDate(initialPropValue)) return initialPropValue;
+    if (typeof initialPropValue === 'string') return stringToDate(initialPropValue, format);
+    return null;
+  })();
+
+  const initialValue = (() => {
+    if (isDate(initialPropValue)) return formatDateTime(initialPropValue, format);
+    if (typeof initialPropValue === 'string') return initialPropValue;
+    return '';
+  })();
+
+  const stringValue = isDate(initialPropValue) || initialPropValue === null || initialPropValue === undefined ? '' : initialPropValue as string;
 
   const initialState = {
-    date: null,
-    value: '',
+    date: initialDate,
+    value: initialValue,
     isValid: true,
     isFocused: false,
     isOpen: false,

--- a/chili/src/DateTimeInput/types.ts
+++ b/chili/src/DateTimeInput/types.ts
@@ -105,6 +105,8 @@ export interface DateTimeInputProps extends ValidationProps {
   onFocus?: (ev: FocusEvent) => void,
   /** Placeholder */
   placeholder?: string,
+  /** Default value */
+  defaultValue?: string | Date | null,
   /** Theme */
   theme?: PartialGlobalDefaultTheme[typeof COMPONENTS_NAMESPACES.dateTimeInput],
   /** Component type */

--- a/docs/src/app/form-components/date-picker/page.tsx
+++ b/docs/src/app/form-components/date-picker/page.tsx
@@ -16,6 +16,11 @@ const DatePickerPage = () => (
 
     <PropsTableSection>
       <tr>
+        <Td>defaultValue</Td>
+        <Td>string | Date | null</Td>
+        <Td>Default value</Td>
+      </tr>
+      <tr>
         <Td>format</Td>
         <Td>string</Td>
         <Td>dd.MM.yyyy is default</Td>


### PR DESCRIPTION
## Summary
- support `defaultValue` for `DatePicker`
- handle default value in DateTimeInput state and reset handler
- document new prop
- fix docs table order
- move DatePicker change handler into its own file

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*
- `npm test` *(fails: jest not found)*
- `npm run tsc` *(fails to compile, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68863a98702c8326826861a77cb03349