### PR TITLE
Add defaultValue demo tab for DatePicker

### DIFF
--- a/docs/src/app/form-components/date-picker/_demo/DefaultValue.tsx
+++ b/docs/src/app/form-components/date-picker/_demo/DefaultValue.tsx
@@ -1,0 +1,25 @@
+import * as L from '@chili';
+import { DatesLive } from '@/components/live/DatesLive';
+import { log } from '@/utils';
+
+export const DefaultValue = () => (
+  <div>
+    <DatesLive scope={{ L, log }}>
+      {
+          `
+() => {
+  return (
+    <L.DatePicker
+      defaultValue={new Date()}
+      onChange={({ component }) => {
+        log(component.value)
+      }}
+      _w-48
+    />
+  )
+}
+  `
+        }
+    </DatesLive>
+  </div>
+);

--- a/docs/src/app/form-components/date-picker/page.tsx
+++ b/docs/src/app/form-components/date-picker/page.tsx
@@ -9,6 +9,7 @@ import { Form } from './_demo/Form';
 import { Required } from './_demo/Required';
 import { Reset } from './_demo/Reset';
 import { Uncontrolled } from './_demo/Uncontrolled';
+import { DefaultValue } from './_demo/DefaultValue';
 
 const DatePickerPage = () => (
   <article>
@@ -114,6 +115,9 @@ const DatePickerPage = () => (
         </Tab>
         <Tab title="Required" tabKey={4}>
           <Required />
+        </Tab>
+        <Tab title="Default value" tabKey={5}>
+          <DefaultValue />
         </Tab>
       </Tabs>
     </Section>


### PR DESCRIPTION
## Summary
- document `defaultValue` prop in DatePicker examples
- add new `DefaultValue` demo and tab in docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688641998cfc832687ab4f3040b8003c