### PR TITLE
Fix DatePicker reset with default value

### DIFF
--- a/chili/components/DatePicker/index.tsx
+++ b/chili/components/DatePicker/index.tsx
@@ -23,6 +23,7 @@ export const DatePicker = React.forwardRef((rawProps: DatePickerProps, ref: Reac
   return (
     <DateTimeInput
       {...restProps}
+      defaultValue={defaultValue}
       value={value}
       onChange={handleChange}
       format={props.format || 'dd.MM.yyyy'}


### PR DESCRIPTION
## Summary
- ensure defaultValue prop is passed down to DateTimeInput so reset works as expected

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*
- `npm run tsc` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6886438c89cc8326801002b05a94e036