### PR TITLE
Adjust live code theme to be more green

### DIFF
--- a/docs/src/components/live/DatesLive.tsx
+++ b/docs/src/components/live/DatesLive.tsx
@@ -7,8 +7,16 @@ import {
 import { themes } from 'prism-react-renderer';
 import { liveFont } from '@/fonts';
 
-const liveTheme = themes.vsLight;
+// base theme from VS Light but adjust to have green tones
+const liveTheme = { ...themes.vsLight };
 liveTheme.plain.backgroundColor = 'transparent';
+const BLUE_COLORS = ['#005cc5', '#0969da', '#79c0ff', '#539bf5'];
+liveTheme.styles = liveTheme.styles.map((s) => {
+  if (s.style && BLUE_COLORS.includes(s.style.color)) {
+    return { ...s, style: { ...s.style, color: '#2da44e' } };
+  }
+  return s;
+});
 
 export const DatesLive = ({
   scope,

--- a/docs/src/components/live/index.tsx
+++ b/docs/src/components/live/index.tsx
@@ -7,8 +7,17 @@ import {
 import { themes } from 'prism-react-renderer';
 import { liveFont } from '@/fonts';
 
-const liveTheme = themes.github;
+// use the GitHub theme but tweak colors slightly
+const liveTheme = { ...themes.github };
 liveTheme.plain.backgroundColor = 'transparent';
+// change default blue accents to a green tone
+const BLUE_COLORS = ['#005cc5', '#0969da', '#79c0ff', '#539bf5'];
+liveTheme.styles = liveTheme.styles.map((s) => {
+  if (s.style && BLUE_COLORS.includes(s.style.color)) {
+    return { ...s, style: { ...s.style, color: '#2da44e' } };
+  }
+  return s;
+});
 
 export const Live = ({
   scope,


### PR DESCRIPTION
## Summary
- tweak live code theme colors to shift blues toward a green accent

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68864934b410832689326715341049d3