### PR TITLE
Add defaultValue support to date range components

### DIFF
--- a/chili/components/DateRange/handlers.ts
+++ b/chili/components/DateRange/handlers.ts
@@ -1,0 +1,16 @@
+import { isFunction } from 'lodash';
+import type { SetState } from '../../commonTypes';
+import type { DateRangeProps, CustomRangeEvent } from './types';
+
+export const createChangeHandler = (
+  props: DateRangeProps,
+  setUncontrolledValue: SetState<DateRangeProps['value']>,
+) => (ev: CustomRangeEvent): void => {
+  const { onChange, value } = props;
+
+  if (value === undefined) {
+    setUncontrolledValue(ev.component.date);
+  }
+
+  if (isFunction(onChange)) onChange(ev);
+};

--- a/chili/components/DateRange/index.tsx
+++ b/chili/components/DateRange/index.tsx
@@ -3,15 +3,33 @@
 import * as React from 'react';
 import { COMPONENT_TYPES } from '../../src/DateTimeInput/constants';
 import { DateTimeInputRange } from '../../src/DateTimeInputRange';
+import { useProps, useValue } from '../../utils';
 import type { DateRangeProps } from './types';
+import { createChangeHandler } from './handlers';
 
-export const DateRange = React.forwardRef((props: DateRangeProps, ref: React.Ref<HTMLElement>) => (
-  <DateTimeInputRange
-    {...props}
-    type={COMPONENT_TYPES.DATE_ONLY}
-    format={props.format || 'dd.MM.yyyy'}
-    ref={ref}
-  />
-)) as React.FC<DateRangeProps>;
+export const DateRange = React.forwardRef((rawProps: DateRangeProps, ref: React.Ref<HTMLElement>) => {
+  const props = useProps(rawProps);
+
+  const {
+    defaultValue = [null, null],
+    value: valueProp,
+    ...restProps
+  } = props;
+
+  const [value, setUncontrolledValue] = useValue<DateRangeProps['value']>(valueProp, defaultValue);
+
+  const handleChange = createChangeHandler(props, setUncontrolledValue);
+
+  return (
+    <DateTimeInputRange
+      {...restProps}
+      type={COMPONENT_TYPES.DATE_ONLY}
+      format={props.format || 'dd.MM.yyyy'}
+      value={value}
+      onChange={handleChange}
+      ref={ref}
+    />
+  );
+}) as React.FC<DateRangeProps>;
 
 DateRange.displayName = 'DateRange';

--- a/chili/components/DateRange/types.ts
+++ b/chili/components/DateRange/types.ts
@@ -7,6 +7,8 @@ import type {
 } from '../../src/DateTimeInputRange/types';
 
 export interface DateRangeProps extends DateTimeInputRangeProps {
+  /** Default value */
+  defaultValue?: [string, string] | [Date | null, Date | null],
   /** Date format, dd.MM.yyyy by default */
   format?: string,
   /** Disabled input state */

--- a/chili/components/DateTimePicker/handlers.ts
+++ b/chili/components/DateTimePicker/handlers.ts
@@ -1,0 +1,16 @@
+import { isFunction } from 'lodash';
+import type { SetState } from '../../commonTypes';
+import type { DateTimePickerProps, ChangeEvent } from './types';
+
+export const createChangeHandler = (
+  props: DateTimePickerProps,
+  setUncontrolledValue: SetState<string | Date | null>,
+) => (ev: ChangeEvent): void => {
+  const { onChange, value } = props;
+
+  if (value === undefined) {
+    setUncontrolledValue(ev.component.date ?? ev.component.value);
+  }
+
+  if (isFunction(onChange)) onChange(ev);
+};

--- a/chili/components/DateTimePicker/index.tsx
+++ b/chili/components/DateTimePicker/index.tsx
@@ -3,15 +3,33 @@
 import * as React from 'react';
 import { DateTimeInput } from '../../src/DateTimeInput';
 import { COMPONENT_TYPES } from '../../src/DateTimeInput/constants';
+import { useProps, useValue } from '../../utils';
 import type { DateTimePickerProps } from './types';
+import { createChangeHandler } from './handlers';
 
-export const DateTimePicker = React.forwardRef((props: DateTimePickerProps, ref: React.Ref<HTMLElement>) => (
-  <DateTimeInput
-    {...props}
-    format={props.format || 'dd.MM.yyyy hh:mm'}
-    ref={ref}
-    type={COMPONENT_TYPES.DATE_TIME}
-  />
-)) as React.FC<DateTimePickerProps>;
+export const DateTimePicker = React.forwardRef((rawProps: DateTimePickerProps, ref: React.Ref<HTMLElement>) => {
+  const props = useProps(rawProps);
+
+  const {
+    defaultValue = null,
+    value: valueProp,
+    ...restProps
+  } = props;
+
+  const [value, setUncontrolledValue] = useValue<string | Date | null>(valueProp, defaultValue);
+
+  const handleChange = createChangeHandler(props, setUncontrolledValue);
+
+  return (
+    <DateTimeInput
+      {...restProps}
+      format={props.format || 'dd.MM.yyyy hh:mm'}
+      value={value}
+      onChange={handleChange}
+      ref={ref}
+      type={COMPONENT_TYPES.DATE_TIME}
+    />
+  );
+}) as React.FC<DateTimePickerProps>;
 
 DateTimePicker.displayName = 'DateTimePicker';

--- a/chili/components/DateTimePicker/types.ts
+++ b/chili/components/DateTimePicker/types.ts
@@ -4,6 +4,8 @@ import type {
 } from '../../src/DateTimeInput/types';
 
 export interface DateTimePickerProps extends DateTimeInputProps {
+  /** Default value */
+  defaultValue?: string | Date | null,
   /** Date format, dd.MM.yyyy hh:mm by default */
   format?: string,
   /** Control opened state */

--- a/chili/components/DateTimeRange/handlers.ts
+++ b/chili/components/DateTimeRange/handlers.ts
@@ -1,0 +1,16 @@
+import { isFunction } from 'lodash';
+import type { SetState } from '../../commonTypes';
+import type { DateTimeRangeProps, CustomRangeEvent } from './types';
+
+export const createChangeHandler = (
+  props: DateTimeRangeProps,
+  setUncontrolledValue: SetState<DateTimeRangeProps['value']>,
+) => (ev: CustomRangeEvent): void => {
+  const { onChange, value } = props;
+
+  if (value === undefined) {
+    setUncontrolledValue(ev.component.date);
+  }
+
+  if (isFunction(onChange)) onChange(ev);
+};

--- a/chili/components/DateTimeRange/index.tsx
+++ b/chili/components/DateTimeRange/index.tsx
@@ -3,15 +3,33 @@
 import * as React from 'react';
 import { DateTimeInputRange } from '../../src/DateTimeInputRange';
 import { COMPONENT_TYPES } from '../../src/DateTimeInput/constants';
+import { useProps, useValue } from '../../utils';
 import type { DateTimeRangeProps } from './types';
+import { createChangeHandler } from './handlers';
 
-export const DateTimeRange = React.forwardRef((props: DateTimeRangeProps, ref: React.Ref<HTMLElement>) => (
-  <DateTimeInputRange
-    {...props}
-    type={COMPONENT_TYPES.DATE_TIME}
-    format={props.format || 'dd.MM.yyyy hh:mm'}
-    ref={ref}
-  />
-)) as React.FC<DateTimeRangeProps>;
+export const DateTimeRange = React.forwardRef((rawProps: DateTimeRangeProps, ref: React.Ref<HTMLElement>) => {
+  const props = useProps(rawProps);
+
+  const {
+    defaultValue = [null, null],
+    value: valueProp,
+    ...restProps
+  } = props;
+
+  const [value, setUncontrolledValue] = useValue<DateTimeRangeProps['value']>(valueProp, defaultValue);
+
+  const handleChange = createChangeHandler(props, setUncontrolledValue);
+
+  return (
+    <DateTimeInputRange
+      {...restProps}
+      type={COMPONENT_TYPES.DATE_TIME}
+      format={props.format || 'dd.MM.yyyy hh:mm'}
+      value={value}
+      onChange={handleChange}
+      ref={ref}
+    />
+  );
+}) as React.FC<DateTimeRangeProps>;
 
 DateTimeRange.displayName = 'DateTimeRange';

--- a/chili/components/DateTimeRange/types.ts
+++ b/chili/components/DateTimeRange/types.ts
@@ -7,6 +7,8 @@ import type {
 } from '../../src/DateTimeInputRange/types';
 
 export interface DateTimeRangeProps extends DateTimeInputRangeProps {
+  /** Default value */
+  defaultValue?: [string, string] | [Date | null, Date | null],
   /** Date format, dd.MM.yyyy hh:mm by default */
   format?: string,
   /** Disabled input state */

--- a/docs/src/app/form-components/date-range/_demo/DefaultValue.tsx
+++ b/docs/src/app/form-components/date-range/_demo/DefaultValue.tsx
@@ -1,0 +1,33 @@
+import * as L from '@chili';
+import { DatesLive } from '@/components/live/DatesLive';
+import { log } from '@/utils';
+
+export const DefaultValue = () => (
+  <div>
+    <DatesLive scope={{ L, log }}>
+      {`
+() => {
+  return (
+    <>
+    <L.DateRange
+      defaultValue={[new Date(), new Date()]}
+      onChange={({ component }) => {
+        log(component.value);
+      }}
+      form="date-range-default-value"
+      name="date-range"
+      _w-96
+      _mb-4
+    />
+    <L.Button
+      onClick={() => console.log(L.form('date-range-default-value', 'date-range').reset())}
+    >
+      reset
+    </L.Button>
+    </>
+  )
+}
+        `}
+    </DatesLive>
+  </div>
+);

--- a/docs/src/app/form-components/date-range/page.tsx
+++ b/docs/src/app/form-components/date-range/page.tsx
@@ -8,12 +8,18 @@ import { Controlled } from './_demo/Controlled';
 import { Form } from './_demo/Form';
 import { Required } from './_demo/Required';
 import { Uncontrolled } from './_demo/Uncontrolled';
+import { DefaultValue } from './_demo/DefaultValue';
 
 const DateRangePage = () => (
   <article>
     <H1>DateRange</H1>
 
     <PropsTableSection>
+      <tr>
+        <Td>defaultValue</Td>
+        <Td>[string, string] | [Date | null, Date | null]</Td>
+        <Td>Default value</Td>
+      </tr>
       <tr>
         <Td>format</Td>
         <Td>string</Td>
@@ -86,6 +92,9 @@ const DateRangePage = () => (
         </Tab>
         <Tab title="Required" tabKey={3}>
           <Required />
+        </Tab>
+        <Tab title="Default value" tabKey={4}>
+          <DefaultValue />
         </Tab>
       </Tabs>
     </Section>

--- a/docs/src/app/form-components/date-time-picker/_demo/DefaultValue.tsx
+++ b/docs/src/app/form-components/date-time-picker/_demo/DefaultValue.tsx
@@ -1,0 +1,33 @@
+import * as L from '@chili';
+import { DatesLive } from '@/components/live/DatesLive';
+import { log } from '@/utils';
+
+export const DefaultValue = () => (
+  <div>
+    <DatesLive scope={{ L, log }}>
+      {`
+() => {
+  return (
+    <>
+    <L.DateTimePicker
+      defaultValue={new Date()}
+      onChange={({ component }) => {
+        log(component.value);
+      }}
+      form="date-time-picker-default-value"
+      name="date-field"
+      _w-48
+      _mb-4
+    />
+    <L.Button
+      onClick={() => console.log(L.form('date-time-picker-default-value', 'date-field').reset())}
+    >
+      reset
+    </L.Button>
+    </>
+  )
+}
+        `}
+    </DatesLive>
+  </div>
+);

--- a/docs/src/app/form-components/date-time-picker/page.tsx
+++ b/docs/src/app/form-components/date-time-picker/page.tsx
@@ -9,12 +9,18 @@ import { Form } from './_demo/Form';
 import { Required } from './_demo/Required';
 import { Reset } from './_demo/Reset';
 import { Uncontrolled } from './_demo/Uncontrolled';
+import { DefaultValue } from './_demo/DefaultValue';
 
 const DateTimePickerPage = () => (
   <article>
     <H1>DateTimePicker</H1>
 
     <PropsTableSection>
+      <tr>
+        <Td>defaultValue</Td>
+        <Td>string | Date | null</Td>
+        <Td>Default value</Td>
+      </tr>
       <tr>
         <Td>format</Td>
         <Td>string</Td>
@@ -105,6 +111,9 @@ const DateTimePickerPage = () => (
         </Tab>
         <Tab title="Required" tabKey={4}>
           <Required />
+        </Tab>
+        <Tab title="Default value" tabKey={5}>
+          <DefaultValue />
         </Tab>
       </Tabs>
     </Section>

--- a/docs/src/app/form-components/date-time-range/_demo/DefaultValue.tsx
+++ b/docs/src/app/form-components/date-time-range/_demo/DefaultValue.tsx
@@ -1,0 +1,33 @@
+import * as L from '@chili';
+import { DatesLive } from '@/components/live/DatesLive';
+import { log } from '@/utils';
+
+export const DefaultValue = () => (
+  <div>
+    <DatesLive scope={{ L, log }}>
+      {`
+() => {
+  return (
+    <>
+    <L.DateTimeRange
+      defaultValue={[new Date(), new Date()]}
+      onChange={({ component }) => {
+        log(component.value);
+      }}
+      form="date-time-range-default-value"
+      name="date-range"
+      _w-96
+      _mb-4
+    />
+    <L.Button
+      onClick={() => console.log(L.form('date-time-range-default-value', 'date-range').reset())}
+    >
+      reset
+    </L.Button>
+    </>
+  )
+}
+        `}
+    </DatesLive>
+  </div>
+);

--- a/docs/src/app/form-components/date-time-range/page.tsx
+++ b/docs/src/app/form-components/date-time-range/page.tsx
@@ -8,12 +8,18 @@ import { Controlled } from './_demo/Controlled';
 import { Form } from './_demo/Form';
 import { Required } from './_demo/Required';
 import { Uncontrolled } from './_demo/Uncontrolled';
+import { DefaultValue } from './_demo/DefaultValue';
 
 const DateTimeRangePage = () => (
   <article>
     <H1>DateTimeRange</H1>
 
-    <PropsTableSection>
+  <PropsTableSection>
+      <tr>
+        <Td>defaultValue</Td>
+        <Td>[string, string] | [Date | null, Date | null]</Td>
+        <Td>Default value</Td>
+      </tr>
       <tr>
         <Td>format</Td>
         <Td>string</Td>
@@ -86,6 +92,9 @@ const DateTimeRangePage = () => (
         </Tab>
         <Tab title="Required" tabKey={3}>
           <Required />
+        </Tab>
+        <Tab title="Default value" tabKey={4}>
+          <DefaultValue />
         </Tab>
       </Tabs>
     </Section>


### PR DESCRIPTION
## Summary
- add defaultValue prop to DateRange, DateTimePicker, and DateTimeRange
- handle uncontrolled state with new handlers
- document defaultValue usage in docs
- include examples for default value tabs

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68864746a194832683ba64a9e8e5f743