### PR TITLE
Fix reset for date components

### DIFF
--- a/chili/components/DateRange/index.tsx
+++ b/chili/components/DateRange/index.tsx
@@ -25,6 +25,7 @@ export const DateRange = React.forwardRef((rawProps: DateRangeProps, ref: React.
       {...restProps}
       type={COMPONENT_TYPES.DATE_ONLY}
       format={props.format || 'dd.MM.yyyy'}
+      defaultValue={defaultValue}
       value={value}
       onChange={handleChange}
       ref={ref}

--- a/chili/components/DateTimePicker/index.tsx
+++ b/chili/components/DateTimePicker/index.tsx
@@ -24,6 +24,7 @@ export const DateTimePicker = React.forwardRef((rawProps: DateTimePickerProps, r
     <DateTimeInput
       {...restProps}
       format={props.format || 'dd.MM.yyyy hh:mm'}
+      defaultValue={defaultValue}
       value={value}
       onChange={handleChange}
       ref={ref}

--- a/chili/components/DateTimeRange/index.tsx
+++ b/chili/components/DateTimeRange/index.tsx
@@ -25,6 +25,7 @@ export const DateTimeRange = React.forwardRef((rawProps: DateTimeRangeProps, ref
       {...restProps}
       type={COMPONENT_TYPES.DATE_TIME}
       format={props.format || 'dd.MM.yyyy hh:mm'}
+      defaultValue={defaultValue}
       value={value}
       onChange={handleChange}
       ref={ref}

--- a/chili/src/DateTimeInputRange/helpers.ts
+++ b/chili/src/DateTimeInputRange/helpers.ts
@@ -10,13 +10,15 @@ export const isDateValue = (value: DateTimeInputRangeProps['value']): value is [
   && (isNil(value[1]) || isDate(value[1]));
 
 export const getDateRangeFromValue = (props: DateTimeInputRangeProps): [Date | null, Date | null] => {
-  const { value: valueProp, format } = props;
+  const { value: valueProp, defaultValue, format } = props;
 
-  if (!valueProp) return [null, null];
+  const currentValue = valueProp === undefined ? defaultValue : valueProp;
 
-  if (isDateValue(valueProp)) return valueProp;
+  if (!currentValue) return [null, null];
 
-  return [stringToDate(valueProp[0], format), stringToDate(valueProp[1], format)];
+  if (isDateValue(currentValue)) return currentValue;
+
+  return [stringToDate(currentValue[0], format), stringToDate(currentValue[1], format)];
 };
 
 export const getPlaceholder = (placeholder?: [string | undefined, string | undefined] | string): [string | undefined, string | undefined] => {

--- a/chili/src/DateTimeInputRange/index.tsx
+++ b/chili/src/DateTimeInputRange/index.tsx
@@ -41,6 +41,7 @@ export const DateTimeInputRange = React.forwardRef((props: DateTimeInputRangePro
     placeholder: placeholderProp,
     theme: themeProp,
     type,
+    defaultValue,
     value: valueProp,
     weeksRowRender,
     wrapperRangeRender,
@@ -123,6 +124,7 @@ export const DateTimeInputRange = React.forwardRef((props: DateTimeInputRangePro
         onEnterPress={handleEnterPress('from')}
         onFocus={onFocus}
         placeholder={placeholders[0]}
+        defaultValue={defaultValue?.[0] ?? null}
         theme={theme.from}
         type={type}
         value={value[0]}
@@ -155,6 +157,7 @@ export const DateTimeInputRange = React.forwardRef((props: DateTimeInputRangePro
         onFocus={onFocus}
         placeholder={placeholders[1]}
         ref={toDateTimeInputRef}
+        defaultValue={defaultValue?.[1] ?? null}
         theme={theme.to}
         type={type}
         value={value[1]}

--- a/chili/src/DateTimeInputRange/types.ts
+++ b/chili/src/DateTimeInputRange/types.ts
@@ -46,6 +46,8 @@ export interface DelimiterProps {
 }
 
 export interface DateTimeInputRangeProps {
+  /** Default value */
+  defaultValue?: [string, string] | [Date | null, Date | null],
   boundingContainerRef?: React.RefObject<HTMLElement>,
   className?: string,
   max?: Date,


### PR DESCRIPTION
## Summary
- preserve default values when resetting DateRange, DateTimePicker and DateTimeRange
- allow DateTimeInputRange to accept `defaultValue`
- forward default values to DateTimeInput components

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "airbnb")*
- `npm run test` *(fails: jest not found)*
- `npm run tsc` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_688652fd8e5c83269c6e338dba4521b8