### PR TITLE
Fix reset for date range components

### DIFF
--- a/chili/components/DateRange/handlers.ts
+++ b/chili/components/DateRange/handlers.ts
@@ -1,4 +1,5 @@
 import { isFunction } from 'lodash';
+import { stringToDate, formatDateTime } from '../../src/DateTimeInput/helpers';
 import type { SetState } from '../../commonTypes';
 import type { DateRangeProps } from './types';
 import type {
@@ -16,4 +17,35 @@ export const createChangeHandler = (
   }
 
   if (isFunction(onChange)) onChange(ev);
+};
+
+export const createResetHandler = (
+  props: DateRangeProps,
+  setUncontrolledValue: SetState<DateRangeProps['value']>,
+) => (): void => {
+  const { defaultValue = [null, null], format = 'dd.MM.yyyy', onChange, value, name } = props;
+
+  const date: [Date | null, Date | null] = [
+    typeof defaultValue[0] === 'string' ? stringToDate(defaultValue[0], format) : defaultValue[0],
+    typeof defaultValue[1] === 'string' ? stringToDate(defaultValue[1], format) : defaultValue[1],
+  ];
+
+  const stringValue: [string, string] = [
+    formatDateTime(date[0], format),
+    formatDateTime(date[1], format),
+  ];
+
+  if (value === undefined) {
+    setUncontrolledValue(date as DateRangeProps['value']);
+  }
+
+  if (isFunction(onChange)) {
+    onChange({
+      component: {
+        date,
+        value: stringValue,
+        name,
+      },
+    } as unknown as CustomRangeEvent);
+  }
 };

--- a/chili/components/DateRange/index.tsx
+++ b/chili/components/DateRange/index.tsx
@@ -4,8 +4,9 @@ import * as React from 'react';
 import { COMPONENT_TYPES } from '../../src/DateTimeInput/constants';
 import { DateTimeInputRange } from '../../src/DateTimeInputRange';
 import { useProps, useValue } from '../../utils';
+import { useValidation } from '../Validation';
 import type { DateRangeProps } from './types';
-import { createChangeHandler } from './handlers';
+import { createChangeHandler, createResetHandler } from './handlers';
 
 export const DateRange = React.forwardRef((rawProps: DateRangeProps, ref: React.Ref<HTMLElement>) => {
   const props = useProps(rawProps);
@@ -17,6 +18,8 @@ export const DateRange = React.forwardRef((rawProps: DateRangeProps, ref: React.
   } = props;
 
   const [value, setUncontrolledValue] = useValue<DateRangeProps['value']>(valueProp, defaultValue);
+
+  useValidation(props, { value }, { reset: createResetHandler(props, setUncontrolledValue) });
 
   const handleChange = createChangeHandler(props, setUncontrolledValue);
 

--- a/chili/components/DateTimeRange/handlers.ts
+++ b/chili/components/DateTimeRange/handlers.ts
@@ -4,6 +4,7 @@ import type { DateTimeRangeProps } from './types';
 import type {
   CustomRangeEvent,
 } from '../../src/DateTimeInputRange/types';
+import { stringToDate, formatDateTime } from '../../src/DateTimeInput/helpers';
 
 export const createChangeHandler = (
   props: DateTimeRangeProps,
@@ -16,4 +17,35 @@ export const createChangeHandler = (
   }
 
   if (isFunction(onChange)) onChange(ev);
+};
+
+export const createResetHandler = (
+  props: DateTimeRangeProps,
+  setUncontrolledValue: SetState<DateTimeRangeProps['value']>,
+) => (): void => {
+  const { defaultValue = [null, null], format = 'dd.MM.yyyy hh:mm', onChange, value, name } = props;
+
+  const date: [Date | null, Date | null] = [
+    typeof defaultValue[0] === 'string' ? stringToDate(defaultValue[0], format) : defaultValue[0],
+    typeof defaultValue[1] === 'string' ? stringToDate(defaultValue[1], format) : defaultValue[1],
+  ];
+
+  const stringValue: [string, string] = [
+    formatDateTime(date[0], format),
+    formatDateTime(date[1], format),
+  ];
+
+  if (value === undefined) {
+    setUncontrolledValue(date as DateTimeRangeProps['value']);
+  }
+
+  if (isFunction(onChange)) {
+    onChange({
+      component: {
+        date,
+        value: stringValue,
+        name,
+      },
+    } as unknown as CustomRangeEvent);
+  }
 };

--- a/chili/components/DateTimeRange/index.tsx
+++ b/chili/components/DateTimeRange/index.tsx
@@ -4,8 +4,9 @@ import * as React from 'react';
 import { DateTimeInputRange } from '../../src/DateTimeInputRange';
 import { COMPONENT_TYPES } from '../../src/DateTimeInput/constants';
 import { useProps, useValue } from '../../utils';
+import { useValidation } from '../Validation';
 import type { DateTimeRangeProps } from './types';
-import { createChangeHandler } from './handlers';
+import { createChangeHandler, createResetHandler } from './handlers';
 
 export const DateTimeRange = React.forwardRef((rawProps: DateTimeRangeProps, ref: React.Ref<HTMLElement>) => {
   const props = useProps(rawProps);
@@ -17,6 +18,8 @@ export const DateTimeRange = React.forwardRef((rawProps: DateTimeRangeProps, ref
   } = props;
 
   const [value, setUncontrolledValue] = useValue<DateTimeRangeProps['value']>(valueProp, defaultValue);
+
+  useValidation(props, { value }, { reset: createResetHandler(props, setUncontrolledValue) });
 
   const handleChange = createChangeHandler(props, setUncontrolledValue);
 


### PR DESCRIPTION
## Summary
- update handlers for DateRange/DateTimeRange to correctly reset to provided defaultValue
- register reset handlers via `useValidation`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68865903abb88326ac815e1d80ce9193