### PR TITLE
Fix DateRange reset with defaults

### DIFF
--- a/chili/components/DateRange/handlers.ts
+++ b/chili/components/DateRange/handlers.ts
@@ -4,6 +4,7 @@ import type { DateRangeProps } from './types';
 import type {
   CustomRangeEvent,
 } from '../../src/DateTimeInputRange/types';
+import { stringToDate, formatDateTime } from '../../src/DateTimeInput/helpers';
 
 export const createChangeHandler = (
   props: DateRangeProps,
@@ -16,4 +17,49 @@ export const createChangeHandler = (
   }
 
   if (isFunction(onChange)) onChange(ev);
+};
+
+export const createResetHandler = (
+  props: DateRangeProps,
+  setUncontrolledValue: SetState<DateRangeProps['value']>,
+) => () => {
+  const {
+    defaultValue = [null, null],
+    format = 'dd.MM.yyyy',
+    name,
+    onChange,
+    value,
+  } = props;
+
+  const date: [Date | null, Date | null] = [
+    typeof defaultValue[0] === 'string'
+      ? stringToDate(defaultValue[0], format)
+      : defaultValue[0],
+    typeof defaultValue[1] === 'string'
+      ? stringToDate(defaultValue[1], format)
+      : defaultValue[1],
+  ];
+
+  if (value === undefined) {
+    setUncontrolledValue(date);
+  }
+
+  if (isFunction(onChange)) {
+    const stringValue: [string, string] = [
+      typeof defaultValue[0] === 'string'
+        ? defaultValue[0]
+        : formatDateTime(defaultValue[0], format),
+      typeof defaultValue[1] === 'string'
+        ? defaultValue[1]
+        : formatDateTime(defaultValue[1], format),
+    ];
+
+    onChange({
+      component: {
+        date,
+        value: stringValue,
+        name,
+      },
+    });
+  }
 };

--- a/chili/components/DateRange/index.tsx
+++ b/chili/components/DateRange/index.tsx
@@ -4,8 +4,9 @@ import * as React from 'react';
 import { COMPONENT_TYPES } from '../../src/DateTimeInput/constants';
 import { DateTimeInputRange } from '../../src/DateTimeInputRange';
 import { useProps, useValue } from '../../utils';
+import { useValidation } from '../Validation';
 import type { DateRangeProps } from './types';
-import { createChangeHandler } from './handlers';
+import { createChangeHandler, createResetHandler } from './handlers';
 
 export const DateRange = React.forwardRef((rawProps: DateRangeProps, ref: React.Ref<HTMLElement>) => {
   const props = useProps(rawProps);
@@ -17,6 +18,10 @@ export const DateRange = React.forwardRef((rawProps: DateRangeProps, ref: React.
   } = props;
 
   const [value, setUncontrolledValue] = useValue<DateRangeProps['value']>(valueProp, defaultValue);
+
+  useValidation(props, { value }, {
+    reset: createResetHandler(props, setUncontrolledValue),
+  });
 
   const handleChange = createChangeHandler(props, setUncontrolledValue);
 

--- a/chili/src/DateTimeInputRange/handlers.ts
+++ b/chili/src/DateTimeInputRange/handlers.ts
@@ -114,3 +114,40 @@ export const createEnterPressHandler = (
     onEnterPress(ev);
   }
 };
+
+export const createResetHandler = (
+  props: DateTimeInputRangeProps,
+  state: DateTimeInputRangeState,
+) => () => {
+  const { defaultValue = [null, null], format = 'dd.MM.yyyy', name, onChange } = props;
+
+  const date: [Date | null, Date | null] = [
+    typeof defaultValue[0] === 'string'
+      ? stringToDate(defaultValue[0], format)
+      : defaultValue[0],
+    typeof defaultValue[1] === 'string'
+      ? stringToDate(defaultValue[1], format)
+      : defaultValue[1],
+  ];
+
+  state.setDate(date);
+
+  if (isFunction(onChange)) {
+    const value: [string, string] = [
+      typeof defaultValue[0] === 'string'
+        ? defaultValue[0]
+        : formatDateTime(defaultValue[0], format),
+      typeof defaultValue[1] === 'string'
+        ? defaultValue[1]
+        : formatDateTime(defaultValue[1], format),
+    ];
+
+    onChange({
+      component: {
+        date,
+        value,
+        name,
+      },
+    });
+  }
+};

--- a/chili/src/DateTimeInputRange/index.tsx
+++ b/chili/src/DateTimeInputRange/index.tsx
@@ -10,8 +10,9 @@ import {
 } from './helpers';
 import { useCustomElements, useDateRange } from './hooks';
 import {
-  createChangeHandler, createEnterPressHandler, handleErrors,
+  createChangeHandler, createEnterPressHandler, handleErrors, createResetHandler,
 } from './handlers';
+import { useValidation } from '../../components/Validation';
 import type { DateTimeInputRangeProps, DateTimeInputRangeState } from './types';
 
 export const DateTimeInputRange = React.forwardRef((props: DateTimeInputRangeProps, ref: React.Ref<HTMLElement>) => {
@@ -57,9 +58,13 @@ export const DateTimeInputRange = React.forwardRef((props: DateTimeInputRangePro
 
   const toDateTimeInputRef = React.useRef<HTMLInputElement | null>(null);
 
-  const {
+  const {    
     date, setDate,
   } = state;
+
+  useValidation(props, { value: date }, {
+    reset: createResetHandler(props, state),
+  });
 
   const value = isNil(valueProp) ? date : valueProp;
 


### PR DESCRIPTION
## Summary
- add reset handler to DateRange using Validation reset logic
- register DateRange for form validation
- allow DateTimeInputRange to reset to default values

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm run test` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_688663cd5f58832688d2c775cde15dc0