### PR TITLE
feat: add disabled input text color variable

### DIFF
--- a/styles/themes/base/base.variables.css
+++ b/styles/themes/base/base.variables.css
@@ -14,7 +14,7 @@
 
   --chili-font-color: #09090b; /* tailwind neutral 950 */
   --chili-font-color-hihglight: #7f1d1d; /* tailwind neutral 950 */
-  --chili-font-color-disabled: var(--chili-base-color-disabled);
+  --chili-font-color-disabled: #404040; /* tailwind neutral 700 */
 
   /* borders and clickable elements */
   --chili-base-color: #a3a3a3; /* tailwind neutral 400 */
@@ -138,6 +138,7 @@
   --chili-input-line-height: var(--chili-line-height);
   --chili-input-font-weight: var(--chili-font-weight);
   --chili-input-text-color: var(--chili-font-color);
+  --chili-input-text-color-disabled: var(--chili-font-color-disabled);
   --chili-input-border-color: var(--chili-base-color);
   --chili-input-border-color-hover: var(--chili-base-color-hover);
   --chili-input-border-radius: var(--chili-border-radius);

--- a/styles/themes/base/base.variables.css
+++ b/styles/themes/base/base.variables.css
@@ -14,6 +14,7 @@
 
   --chili-font-color: #09090b; /* tailwind neutral 950 */
   --chili-font-color-hihglight: #7f1d1d; /* tailwind neutral 950 */
+  --chili-font-color-disabled: var(--chili-base-color-disabled);
 
   /* borders and clickable elements */
   --chili-base-color: #a3a3a3; /* tailwind neutral 400 */

--- a/styles/themes/base/common/helpers.css
+++ b/styles/themes/base/common/helpers.css
@@ -22,7 +22,7 @@
 
   .chili-input-element {
     background-color: var(--chili-input-bg-color-disabled);
-    color: var(--chili-font-color-disabled);
+    color: var(--chili-input-text-color-disabled);
   }
 
   .chili-input-icon {

--- a/styles/themes/base/common/helpers.css
+++ b/styles/themes/base/common/helpers.css
@@ -10,6 +10,7 @@
 .chili-disabled {
   cursor: not-allowed;
   background-color: var(--chili-input-bg-color-disabled);
+  color: var(--chili-font-color-disabled);
 
   &:hover {
     border-color: var(--chili-input-border-color);
@@ -21,6 +22,7 @@
 
   .chili-input-element {
     background-color: var(--chili-input-bg-color-disabled);
+    color: var(--chili-font-color-disabled);
   }
 
   .chili-input-icon {


### PR DESCRIPTION
## Summary
- add `--chili-font-color-disabled` CSS variable for disabled text color across input fields
- apply the variable in `.chili-disabled` helper so disabled inputs use this text color

## Testing
- `npm test` *(fails: ReferenceError: document is not defined)*
- `npm run lint` *(fails: 12 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68973157f7408326afc8daa44c28460a