### PR TITLE
fix(radio): allow passing name prop to children

### DIFF
--- a/chili/components/Radio/RadioGroup.tsx
+++ b/chili/components/Radio/RadioGroup.tsx
@@ -7,7 +7,11 @@ import {
 import { Div } from '../Div';
 import { COMPONENTS_NAMESPACES } from '../../constants';
 import type {
-  ChangeEvent, RadioGroupProps, WrapperProps,
+  ChangeEvent,
+  RadioButtonProps,
+  PropsFromParent,
+  RadioGroupProps,
+  WrapperProps,
 } from './types';
 import { createResetHandler, createSetValueHandler } from './handlers';
 import { useValidation } from '../Validation';
@@ -63,18 +67,18 @@ export const RadioGroup = React.forwardRef((props: RadioGroupProps, ref?: React.
       ref={ref}
     >
       {React.Children.toArray(children).map((child) => {
-        if (child
+        if (
+          child
           && React.isValidElement(child)
           && (child.type === RadioButton || (child.type as { name?: string }).name === 'RadioButton')
         ) {
-          return React.cloneElement(child, {
+          const radioButtonChild = child as React.ReactElement<RadioButtonProps & PropsFromParent>;
+          return React.cloneElement(radioButtonChild, {
             name,
             onChange: handleChange,
-            isDisabled: isBoolean(isDisabled) ? isDisabled : child.props.isDisabled,
-            isChecked: child.props.value === value,
-            theme: { ...theme, ...child.props.theme },
-          // todo find a better way to fix TS issue with the name property
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            isDisabled: isBoolean(isDisabled) ? isDisabled : radioButtonChild.props.isDisabled,
+            isChecked: radioButtonChild.props.value === value,
+            theme: { ...theme, ...radioButtonChild.props.theme },
           });
         }
         return child;

--- a/chili/components/Radio/types.ts
+++ b/chili/components/Radio/types.ts
@@ -41,7 +41,7 @@ export interface RadioGroupProps extends ValidationProps {
   [x: string]: unknown,
 }
 
-export interface RadioButtonProps extends React.HTMLAttributes<HTMLInputElement> {
+export interface RadioButtonProps extends Omit<React.HTMLAttributes<HTMLInputElement>, 'onChange'> {
   /** Radio button id */
   id?: string,
   /** Disabled state */


### PR DESCRIPTION
## Summary
- ensure RadioGroup forwards name and handlers to RadioButton children with proper typing
- exclude default onChange from RadioButtonProps so custom change events type-check

## Testing
- `npm run tsc`
- `npm run lint` *(fails: defaultValue and format prop-types errors in date components)*
- `npm test` *(fails: jsdom ReferenceError in Notifications tests)*

------
https://chatgpt.com/codex/tasks/task_e_689747484ee08326b124a514447cd67b