### PR TITLE
feat(validation): persist values when fields unmount

### DIFF
--- a/chili/components/Validation/types.ts
+++ b/chili/components/Validation/types.ts
@@ -5,6 +5,8 @@ import type { GlobalDefaultTheme } from '../../utils/useTheme';
 import type { COMPONENTS_NAMESPACES } from '../../constants';
 import type { Suggestion } from '../AutoComplete/types';
 
+export type PersistIn = 'innerStorage' | 'sessionStorage' | 'localStorage';
+
 export interface ValidationProps {
   form?: string,
   name?: string,
@@ -15,6 +17,7 @@ export interface ValidationProps {
   invalidMessage?: string,
   requiredMessage?: string,
   shouldValidateUnmounted?: boolean,
+  persistIn?: PersistIn,
   invalidMessageRender?: CustomRender<ValidationProps, ValidationState, InvalidMessageProps>,
 }
 
@@ -67,6 +70,7 @@ export interface Field {
   setIsValid: SetState<boolean>,
   setMessages: SetState<string[] | undefined>,
   shouldValidateUnmounted: boolean,
+  persistIn?: PersistIn,
   suggestion?: Suggestion,
   validators: NormalizedValidatorObject[],
   value: any,
@@ -111,6 +115,7 @@ export interface AddFieldData {
   setIsValid: SetState<boolean>,
   setMessages: SetState<string[] | undefined>,
   shouldValidateUnmounted?: boolean,
+  persistIn?: PersistIn,
   validators: NormalizedValidatorObject[],
   isRequired?: boolean,
   requiredMessage?: string,
@@ -127,6 +132,7 @@ export interface UpdateFieldData {
   isRequired?: boolean,
   requiredMessage?: string,
   shouldValidateUnmounted?: boolean,
+  persistIn?: PersistIn,
   suggestion?: Suggestion,
   validators: NormalizedValidatorObject[],
 }

--- a/chili/components/Validation/useValidation.tsx
+++ b/chili/components/Validation/useValidation.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { isString, isNil } from 'lodash';
 import { useElement } from '../../utils';
 import {
-  addField, getValidators, removeField, updateField, validate,
+  addField, getValidators, removeField, updateField, validate, getPersistedValue, setPersistedValue,
 } from './helpers';
 import { InvalidMessage as DefaultInvalidMessage } from './InvalidMessage';
 import type {
@@ -21,15 +21,23 @@ export const useValidation = <P extends ValidationProps, S extends ValidationSta
     isRequired = false,
     isValid: isValidProp,
     shouldValidateUnmounted,
+    persistIn,
     validator,
     invalidMessage,
     requiredMessage,
     invalidMessageRender,
   } = props;
 
-  const value = props.value === undefined && state
+  const uncontrolled = props.value === undefined;
+  const persistedValue = form && name && persistIn ? getPersistedValue(form, name, persistIn) : undefined;
+
+  let value = uncontrolled && state
     ? state.value
     : props.value;
+
+  if (uncontrolled && persistedValue !== undefined) {
+    value = persistedValue;
+  }
 
   const [isValid, setIsValid] = React.useState<boolean>(true);
 
@@ -47,6 +55,7 @@ export const useValidation = <P extends ValidationProps, S extends ValidationSta
         setIsValid,
         setMessages,
         shouldValidateUnmounted,
+        persistIn,
         validators,
         isRequired,
         requiredMessage,
@@ -80,11 +89,25 @@ export const useValidation = <P extends ValidationProps, S extends ValidationSta
         isRequired,
         validators,
         shouldValidateUnmounted,
+        persistIn,
         requiredMessage,
         suggestion: state.suggestion,
       });
     }
-  }, [form, isRequired, name, value, isValidProp, validator, invalidMessage, shouldValidateUnmounted, requiredMessage, state.suggestion]);
+  }, [form, isRequired, name, value, isValidProp, validator, invalidMessage, shouldValidateUnmounted, persistIn, requiredMessage, state.suggestion]);
+
+  React.useEffect(() => {
+    if (form && name && persistIn) {
+      setPersistedValue(form, name, persistIn, value);
+    }
+  }, [form, name, persistIn, value]);
+
+  React.useEffect(() => {
+    if (uncontrolled && persistedValue !== undefined) {
+      extra.setValue(persistedValue);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // user gets this function to validate the current field
   // it can be called in a handler, e.g. in onBlur

--- a/chili/form/form.ts
+++ b/chili/form/form.ts
@@ -68,6 +68,7 @@ const getFormFieldHelpers = (formName: string, fieldName: string): FormFieldHelp
         isRequired: field.isRequired,
         requiredMessage: field.requiredMessage,
         shouldValidateUnmounted: field.shouldValidateUnmounted,
+        persistIn: field.persistIn,
         suggestion: field.suggestion,
         validators: field.validators,
       });

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -160,6 +160,12 @@ const Home = () => (
       </P>
 
       <P>
+        <A href="/validation-examples/persistence">
+          Persistence examples
+        </A>
+      </P>
+
+      <P>
         <A href="/validation-examples/predefined-validators">
           More validation examples
         </A>

--- a/docs/src/app/validation-examples/persistence/page.tsx
+++ b/docs/src/app/validation-examples/persistence/page.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import * as L from '@chili';
+import { H1, P } from '@/components/typography';
+import { Live } from '@/components/live';
+import React from 'react';
+
+const PersistencePage = () => (
+  <article>
+    <H1>Persistence</H1>
+
+    <P>
+      Use the <code>persistIn</code> prop to keep field values when components unmount.
+      Values can be stored in inner storage, sessionStorage or localStorage and
+      will be restored on remount.
+    </P>
+
+    <L.Section>
+      <L.Tabs>
+        <L.Tab title="innerStorage" tabKey={0}>
+          <Live scope={{ L, React }}>
+            {`
+() => {
+  const [isVisible, setVisible] = React.useState(true);
+  return (
+    <>
+      <L.Button onClick={() => setVisible(!isVisible)} _mb-3>
+        Toggle
+      </L.Button>
+      {isVisible && (
+        <L.Input
+          form='innerPersistence'
+          name='field'
+          persistIn='innerStorage'
+          placeholder='type something'
+          _w-48
+          _mb-3
+        />
+      )}
+    </>
+  );
+}
+            `}
+          </Live>
+        </L.Tab>
+        <L.Tab title="sessionStorage" tabKey={1}>
+          <Live scope={{ L, React }}>
+            {`
+() => {
+  const [isVisible, setVisible] = React.useState(true);
+  return (
+    <>
+      <L.Button onClick={() => setVisible(!isVisible)} _mb-3>
+        Toggle
+      </L.Button>
+      {isVisible && (
+        <L.Input
+          form='sessionPersistence'
+          name='field'
+          persistIn='sessionStorage'
+          placeholder='type something'
+          _w-48
+          _mb-3
+        />
+      )}
+    </>
+  );
+}
+            `}
+          </Live>
+        </L.Tab>
+        <L.Tab title="localStorage" tabKey={2}>
+          <Live scope={{ L, React }}>
+            {`
+() => {
+  const [isVisible, setVisible] = React.useState(true);
+  return (
+    <>
+      <L.Button onClick={() => setVisible(!isVisible)} _mb-3>
+        Toggle
+      </L.Button>
+      {isVisible && (
+        <L.Input
+          form='localPersistence'
+          name='field'
+          persistIn='localStorage'
+          placeholder='type something'
+          _w-48
+          _mb-3
+        />
+      )}
+    </>
+  );
+}
+            `}
+          </Live>
+        </L.Tab>
+      </L.Tabs>
+    </L.Section>
+  </article>
+);
+
+export default PersistencePage;
+

--- a/docs/src/components/nav/index.tsx
+++ b/docs/src/components/nav/index.tsx
@@ -53,6 +53,7 @@ export const MainNav = () => (
     <ul>
       {/* <NavLi to='/examples/is-required'>isRequired</NavLi> */}
       <NavLi to="/validation-examples/predefined-validators">predefined validators</NavLi>
+      <NavLi to="/validation-examples/persistence">persistence</NavLi>
     </ul>
 
     <div className="py-4 font-bold">

--- a/docs/src/sections/ValidationSection.tsx
+++ b/docs/src/sections/ValidationSection.tsx
@@ -13,6 +13,7 @@ export const ValidationSection = ({
   invalidMessageRender,
   requiredMessage,
   shouldValidateUnmounted,
+  persistIn,
   validator,
 }: {
   all?: boolean,
@@ -24,6 +25,7 @@ export const ValidationSection = ({
   invalidMessageRender?: boolean,
   requiredMessage?: boolean,
   shouldValidateUnmounted?: boolean,
+  persistIn?: boolean,
   validator?: boolean,
 }) => (
   <Section>
@@ -73,6 +75,11 @@ export const ValidationSection = ({
           <TdCode>shouldValidateUnmounted</TdCode>
           <TdCode>boolean</TdCode>
           <Td>The field can still affect form submission even if it is not rendered</Td>
+        </L.Tr>
+        <L.Tr shouldRender={Boolean(all || persistIn)}>
+          <TdCode>persistIn</TdCode>
+          <TdCode>'innerStorage' | 'sessionStorage' | 'localStorage'</TdCode>
+          <Td>Persist field value when unmounted</Td>
         </L.Tr>
 
         <L.Tr shouldRender={Boolean(all || validator)}>


### PR DESCRIPTION
## Summary
- support new `persistIn` prop to keep field values in inner, session or local storage
- retain values for unmounted fields and restore them on remount
- update persisted storage whenever field values change
- document `persistIn` option and add persistence examples

## Testing
- `npm run lint` *(fails: 'defaultValue' is missing in props validation...)*
- `npm test` *(fails: ReferenceError: document is not defined)*
- `npm run tsc`


------
https://chatgpt.com/codex/tasks/task_e_68a1c1dfbe6c8326bc42b17e20d26085