### PR TITLE
fix: support persistence for date pickers

### DIFF
--- a/chili/components/DatePicker/index.tsx
+++ b/chili/components/DatePicker/index.tsx
@@ -24,11 +24,11 @@ export const DatePicker = React.forwardRef((rawProps: DatePickerProps, ref: Reac
     <DateTimeInput
       {...restProps}
       defaultValue={defaultValue}
-      value={value}
       onChange={handleChange}
       format={props.format || 'dd.MM.yyyy'}
       type={COMPONENT_TYPES.DATE_ONLY}
       ref={ref}
+      {...(valueProp !== undefined ? { value } : {})}
     />
   );
 }) as React.FC<DatePickerProps>;

--- a/chili/components/DateRange/index.tsx
+++ b/chili/components/DateRange/index.tsx
@@ -26,9 +26,9 @@ export const DateRange = React.forwardRef((rawProps: DateRangeProps, ref: React.
       type={COMPONENT_TYPES.DATE_ONLY}
       format={props.format || 'dd.MM.yyyy'}
       defaultValue={defaultValue}
-      value={value}
       onChange={handleChange}
       ref={ref}
+      {...(valueProp !== undefined ? { value } : {})}
     />
   );
 }) as React.FC<DateRangeProps>;

--- a/chili/components/DateTimePicker/index.tsx
+++ b/chili/components/DateTimePicker/index.tsx
@@ -25,10 +25,10 @@ export const DateTimePicker = React.forwardRef((rawProps: DateTimePickerProps, r
       {...restProps}
       format={props.format || 'dd.MM.yyyy hh:mm'}
       defaultValue={defaultValue}
-      value={value}
       onChange={handleChange}
       ref={ref}
       type={COMPONENT_TYPES.DATE_TIME}
+      {...(valueProp !== undefined ? { value } : {})}
     />
   );
 }) as React.FC<DateTimePickerProps>;

--- a/chili/components/DateTimeRange/index.tsx
+++ b/chili/components/DateTimeRange/index.tsx
@@ -26,9 +26,9 @@ export const DateTimeRange = React.forwardRef((rawProps: DateTimeRangeProps, ref
       type={COMPONENT_TYPES.DATE_TIME}
       format={props.format || 'dd.MM.yyyy hh:mm'}
       defaultValue={defaultValue}
-      value={value}
       onChange={handleChange}
       ref={ref}
+      {...(valueProp !== undefined ? { value } : {})}
     />
   );
 }) as React.FC<DateTimeRangeProps>;


### PR DESCRIPTION
## Summary
- ensure date-based pickers only pass `value` when controlled so persistence works

## Testing
- `npx jest chili/utils/filterStrHelpers.test.ts --runInBand`
- `npm test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b59d14908883268dd95c6319d3176b