### PR TITLE
feat(DateTimeInput): handle ISO date strings

### DIFF
--- a/chili/src/DateTimeInput/handlers/handleSetValue.test.ts
+++ b/chili/src/DateTimeInput/handlers/handleSetValue.test.ts
@@ -1,0 +1,40 @@
+import { createSetValueHandler } from './handleSetValue';
+import { stateActionTypes } from '../actions';
+import { COMPONENT_TYPES } from '../constants';
+
+describe('createSetValueHandler', () => {
+  it('should handle ISO date string', () => {
+    const dispatch = jest.fn();
+    const onChange = jest.fn();
+
+    const handler = createSetValueHandler({
+      props: {
+        name: 'test',
+        onChange,
+        format: 'dd.MM.yyyy',
+        type: COMPONENT_TYPES.DATE_ONLY,
+      },
+      dispatch,
+    });
+
+    handler('2025-02-01T13:34:00.000Z');
+
+    expect(dispatch).toHaveBeenNthCalledWith(1, {
+      type: stateActionTypes.SET_VALUE,
+      payload: '01.02.2025',
+    });
+
+    const setDateCall = dispatch.mock.calls[1][0];
+    expect(setDateCall.type).toBe(stateActionTypes.SET_DATE);
+    expect(setDateCall.payload).toBeInstanceOf(Date);
+    expect(setDateCall.payload.toISOString()).toBe('2025-02-01T13:34:00.000Z');
+
+    expect(onChange).toHaveBeenCalledWith({
+      component: {
+        name: 'test',
+        date: setDateCall.payload,
+        value: '2025-02-01T13:34:00.000Z',
+      },
+    });
+  });
+});

--- a/chili/src/DateTimeInput/handlers/handleSetValue.ts
+++ b/chili/src/DateTimeInput/handlers/handleSetValue.ts
@@ -21,10 +21,21 @@ export const createSetValueHandler = ({
     type = COMPONENT_TYPES.DATE_ONLY,
   } = props;
 
-  const mask = createMask(format, type);
-  const maskedValue = maskValue(newValueInput, mask);
-  const newDate = stringToDate(maskedValue, format);
-  const newValue = newDate ? formatDateTime(newDate, format) : newValueInput;
+  let newDate: Date | null = null;
+  let preparedValue = newValueInput;
+
+  if (typeof newValueInput === 'string' && /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/.test(newValueInput)) {
+    const dateFromISO = new Date(newValueInput);
+    if (!Number.isNaN(dateFromISO.getTime())) newDate = dateFromISO;
+  }
+
+  if (!newDate) {
+    const mask = createMask(format, type);
+    preparedValue = maskValue(newValueInput, mask);
+    newDate = stringToDate(preparedValue, format);
+  }
+
+  const newValue = newDate ? formatDateTime(newDate, format) : preparedValue;
 
   dispatch(setValue(newValue));
   if (newDate && newDate.getDate()) dispatch(setDate(newDate));


### PR DESCRIPTION
## Summary
- handle ISO 8601 strings in DateTimeInput set value handler
- test ISO string handling for DateTimeInput

## Testing
- `npm test` *(fails: ReferenceError: document is not defined)*
- `npm test -- --env=jsdom` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: prop-types errors in unrelated components)*
- `npx jest chili/src/DateTimeInput/handlers/handleSetValue.test.ts --color --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b5a1b045c88326b527c39d6e296727