### PR TITLE
Handle defaultValue in DateTimeInput to avoid input warnings

### DIFF
--- a/chili/src/DateTimeInput/DateTimeInput.tsx
+++ b/chili/src/DateTimeInput/DateTimeInput.tsx
@@ -60,6 +60,9 @@ export const DateTimeInput = React.forwardRef((props: DateTimeInputProps, ref: R
     theme: themeProp,
     type = COMPONENT_TYPES.DATE_ONLY,
     validator,
+    // defaultValue is captured but not passed through to the underlying <Input>
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    defaultValue: _defaultValue,
     value: valueProp,
     weeksRowRender,
     wrapperRender,


### PR DESCRIPTION
## Summary
- remove DateTimeInput persistence test
- document defaultValue omission so it isn't spread to underlying input

## Testing
- `npm test` *(fails: document is not defined, jsdom test environment missing)*
- `npm run tsc`
- `npm run lint` *(fails: existing prop-types errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b15642a083269d14eacc8e52dc7c