### PR TITLE
Use masked value for validation in MaskedInput

### DIFF
--- a/chili/components/MaskedInput/MaskedInput.persistence.test.tsx
+++ b/chili/components/MaskedInput/MaskedInput.persistence.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MaskedInput } from './index';
+import { Persistence } from '../Validation/types';
+
+describe('MaskedInput PERSISTENCE', () => {
+  it('should restore persisted value without console error', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    window.sessionStorage.clear();
+
+    const { unmount } = render(
+      <MaskedInput
+        mask="###"
+        form="form"
+        name="field"
+        persistence={Persistence.sessionStorage}
+        onChange={jest.fn()}
+      />,
+    );
+
+    userEvent.type(screen.getByRole('textbox'), '123');
+
+    expect(window.sessionStorage.getItem('chili-form-form')).toBe(JSON.stringify({ field: '123' }));
+
+    unmount();
+
+    render(
+      <MaskedInput
+        mask="###"
+        form="form"
+        name="field"
+        persistence={Persistence.sessionStorage}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(await screen.findByDisplayValue('123')).toBeTruthy();
+
+    expect(consoleErrorSpy.mock.calls.flat()).not.toContain('Persistence prop is for uncontrolled state only');
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/chili/components/MaskedInput/index.tsx
+++ b/chili/components/MaskedInput/index.tsx
@@ -59,16 +59,16 @@ export const MaskedInput = React.forwardRef((props: MaskedInputProps, ref: React
 
   const {
     isValid, validateCurrent, InvalidMessage,
-  } = useValidation({
-    ...props, value: valueToValidate,
-  }, {
-    value: valueState,
-  }, {
-    reset: createResetHandler({
-      props, setValue, value: toStringOrEmpty(defaultValue || ''),
-    }),
-    setValue: createSetValueHandler({ props, setValue }),
-  });
+  } = useValidation(
+    props,
+    { value: valueToValidate },
+    {
+      reset: createResetHandler({
+        props, setValue, value: toStringOrEmpty(defaultValue || ''),
+      }),
+      setValue: createSetValueHandler({ props, setValue }),
+    },
+  );
 
   const state = { value: valueState, isFocused, isValid };
 


### PR DESCRIPTION
## Summary
- call `useValidation` with original props and pass masked value through state
- add persistence test to ensure `MaskedInput` restores stored values without console errors

## Testing
- `npx eslint chili/components/MaskedInput/index.tsx chili/components/MaskedInput/MaskedInput.persistence.test.tsx`
- `npm run tsc`
- `npm test chili/components/MaskedInput/MaskedInput.persistence.test.tsx` *(fails: ReferenceError: window is not defined; 25 snapshot files obsolete)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b5d5795c83269b4ec6b2f7047274