### PR TITLE
feat: add persisted form helper

### DIFF
--- a/chili/constants.ts
+++ b/chili/constants.ts
@@ -10,6 +10,8 @@ export const FILE_SIZE_UNITS = {
   TB: 'TB' as const,
 };
 
+export const FORM_STORAGE_PREFIX = 'chili-form-';
+
 export const COMPONENTS_NAMESPACES = {
   accordion: 'accordion',
   autoComplete: 'autoComplete',

--- a/chili/form/getPersistedForm.test.ts
+++ b/chili/form/getPersistedForm.test.ts
@@ -1,0 +1,25 @@
+import { getPersistedForm } from './getPersistedForm';
+import { Persistence } from '../components/Validation/types';
+import { FORM_STORAGE_PREFIX } from '../constants';
+
+describe('getPersistedForm', () => {
+  const formName = 'test-form';
+  const fieldName = 'field';
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  test('returns field value when field provided', () => {
+    const data = { [fieldName]: 'value' };
+    window.localStorage.setItem(`${FORM_STORAGE_PREFIX}${formName}`, JSON.stringify(data));
+    expect(getPersistedForm({ form: formName, persistence: Persistence.localStorage, field: fieldName })).toBe('value');
+  });
+
+  test('returns whole form when field is not provided', () => {
+    const data = { [fieldName]: 'value', another: 1 };
+    window.sessionStorage.setItem(`${FORM_STORAGE_PREFIX}${formName}`, JSON.stringify(data));
+    expect(getPersistedForm({ form: formName, persistence: Persistence.sessionStorage })).toEqual(data);
+  });
+});

--- a/chili/form/getPersistedForm.ts
+++ b/chili/form/getPersistedForm.ts
@@ -1,0 +1,41 @@
+import { Persistence } from '../components/Validation/types';
+import { FORM_STORAGE_PREFIX } from '../constants';
+
+interface GetPersistedFormParams {
+  form: string,
+  persistence: Persistence,
+  field?: string,
+}
+
+const getStorage = (persistence: Persistence) => (
+  persistence === Persistence.localStorage ? window.localStorage : window.sessionStorage
+);
+
+export const getPersistedForm = ({ form, persistence, field }: GetPersistedFormParams) => {
+  const storage = getStorage(persistence);
+  const key = `${FORM_STORAGE_PREFIX}${form}`;
+  const storedValue = storage.getItem(key);
+
+  if (!storedValue) {
+    // eslint-disable-next-line no-console
+    console.warn(`No data found for key: ${key}`);
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(storedValue);
+    if (field) {
+      if (field in parsed) {
+        return parsed[field];
+      }
+      // eslint-disable-next-line no-console
+      console.warn(`Field "${field}" not found in data for key: ${key}`);
+      return null;
+    }
+    return parsed;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(`Error parsing JSON for key: ${key}`, err);
+    return null;
+  }
+};

--- a/chili/form/index.ts
+++ b/chili/form/index.ts
@@ -1,7 +1,9 @@
 import {
   form,
 } from './form';
+import { getPersistedForm } from './getPersistedForm';
 
 export {
   form,
+  getPersistedForm,
 };

--- a/chili/index.ts
+++ b/chili/index.ts
@@ -115,9 +115,8 @@ import * as TooltipTypes from './components/Tooltip/types';
 import * as ValidationTypes from './components/Validation/types';
 import * as commonTypes from './commonTypes';
 
-import { form } from './form';
-
-import { Persistence } from './components/Validation/types'; 
+import { form, getPersistedForm } from './form';
+import { Persistence } from './components/Validation/types';
 
 const utils = {
   bytesSizeToUnitsSize,
@@ -232,6 +231,7 @@ export {
   Chili, ChiliContext,
   validate,
   form,
+  getPersistedForm,
   utils,
   Validation,
   Persistence,

--- a/chili/utils/usePersistence.ts
+++ b/chili/utils/usePersistence.ts
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { Persistence } from '../components/Validation/types';
+import { FORM_STORAGE_PREFIX } from '../constants';
 
 export interface UsePersistenceParams<V> {
   form?: string,
@@ -17,7 +18,7 @@ const getStorage = (persistence: Persistence) => (
   persistence === Persistence.localStorage ? window.localStorage : window.sessionStorage
 );
 
-const getFormKey = (form: string) => `chili-form-${form}`;
+const getFormKey = (form: string) => `${FORM_STORAGE_PREFIX}${form}`;
 
 export const usePersistence = <V>({
   form,


### PR DESCRIPTION
## Summary
- add getPersistedForm helper to read persisted form or field values
- centralize form storage prefix and reuse in persistence utilities
- export new helper alongside form and add tests

## Testing
- `npx eslint chili/form/getPersistedForm.ts chili/form/index.ts chili/index.ts chili/utils/usePersistence.ts chili/constants.ts -f tap`
- `npx tsc --noEmit`
- `npm test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fc3b0e2c83269401b4e8ff774cb4