### PR TITLE
feat(form): add setPersistedForm helper

### DIFF
--- a/chili/form/index.ts
+++ b/chili/form/index.ts
@@ -2,8 +2,10 @@ import {
   form,
 } from './form';
 import { getPersistedForm } from './getPersistedForm';
+import { setPersistedForm } from './setPersistedForm';
 
 export {
   form,
   getPersistedForm,
+  setPersistedForm,
 };

--- a/chili/form/setPersistedForm.test.ts
+++ b/chili/form/setPersistedForm.test.ts
@@ -1,0 +1,41 @@
+import { setPersistedForm } from './setPersistedForm';
+import { Persistence } from '../components/Validation/types';
+import { FORM_STORAGE_PREFIX } from '../constants';
+
+describe('setPersistedForm', () => {
+  const formName = 'test-form';
+  const fieldName = 'field';
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  test('updates persisted field value', () => {
+    const key = `${FORM_STORAGE_PREFIX}${formName}`;
+    window.localStorage.setItem(key, JSON.stringify({ [fieldName]: 'old', another: 1 }));
+
+    setPersistedForm({ form: formName, persistence: Persistence.localStorage, field: fieldName }, 'new');
+
+    expect(JSON.parse(window.localStorage.getItem(key) as string)).toEqual({ [fieldName]: 'new', another: 1 });
+  });
+
+  test('throws when persisted data does not exist', () => {
+    expect(() => setPersistedForm({
+      form: formName,
+      persistence: Persistence.sessionStorage,
+      field: fieldName,
+    }, 'value')).toThrowError(`No data found for key: ${FORM_STORAGE_PREFIX}${formName}`);
+  });
+
+  test('throws when persisted data is not valid JSON', () => {
+    const key = `${FORM_STORAGE_PREFIX}${formName}`;
+    window.sessionStorage.setItem(key, 'invalid json');
+
+    expect(() => setPersistedForm({
+      form: formName,
+      persistence: Persistence.sessionStorage,
+      field: fieldName,
+    }, 'value')).toThrowError(`Error parsing JSON for key: ${key}`);
+  });
+});

--- a/chili/form/setPersistedForm.ts
+++ b/chili/form/setPersistedForm.ts
@@ -1,0 +1,37 @@
+import { Persistence } from '../components/Validation/types';
+import { FORM_STORAGE_PREFIX } from '../constants';
+
+interface SetPersistedFormParams {
+  form: string,
+  persistence: Persistence,
+  field: string,
+}
+
+const getStorage = (persistence: Persistence) => (
+  persistence === Persistence.localStorage ? window.localStorage : window.sessionStorage
+);
+
+export const setPersistedForm = ({ form, persistence, field }: SetPersistedFormParams, value: unknown): void => {
+  const storage = getStorage(persistence);
+  const key = `${FORM_STORAGE_PREFIX}${form}`;
+  const storedValue = storage.getItem(key);
+
+  if (!storedValue) {
+    throw new Error(`No data found for key: ${key}`);
+  }
+
+  let parsed: Record<string, unknown>;
+
+  try {
+    parsed = JSON.parse(storedValue);
+  } catch (err) {
+    throw new Error(`Error parsing JSON for key: ${key}`);
+  }
+
+  const updated = {
+    ...parsed,
+    [field]: value,
+  };
+
+  storage.setItem(key, JSON.stringify(updated));
+};

--- a/chili/index.ts
+++ b/chili/index.ts
@@ -115,7 +115,7 @@ import * as TooltipTypes from './components/Tooltip/types';
 import * as ValidationTypes from './components/Validation/types';
 import * as commonTypes from './commonTypes';
 
-import { form, getPersistedForm } from './form';
+import { form, getPersistedForm, setPersistedForm } from './form';
 import { Persistence } from './components/Validation/types';
 
 const utils = {
@@ -232,6 +232,7 @@ export {
   validate,
   form,
   getPersistedForm,
+  setPersistedForm,
   utils,
   Validation,
   Persistence,


### PR DESCRIPTION
## Summary
- add a setPersistedForm helper for updating persisted form values and export it
- cover the helper with tests that verify update and error paths

## Testing
- npm test *(fails: existing Notifications tests require a jsdom test environment and abort before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7fe7520883269a3cd6583e21f460